### PR TITLE
Switch to core-text 4.0.0 on macOS.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ user32-sys = "0.2"
 gdi32-sys = "0.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-text = "3.0.0"
+core-text = "4.0.0"
 core-foundation = "0.3.0"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]


### PR DESCRIPTION
This should help webrender de-duplicate some dependencies.