### PR TITLE
Bump core-text dependency to 6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "font-loader"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["MSleepyPanda <m.sleepypanda@gmail.com>"]
 license = "MIT"
 readme = "Readme.md"
@@ -19,7 +19,7 @@ user32-sys = "0.2"
 gdi32-sys = "0.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-text = "5.0"
+core-text = "6.0"
 core-foundation = "0.3"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]


### PR DESCRIPTION
This is helpful to avoid core-text version conflicts in servo/webrender#1409, which depends on rust-font-loader. The changes between core-text 5.0 and 6.0 are trivial - the only change is the addition of a feature in the Cargo.toml file that allows opting out of OS X 10.8+-only APIs.