### PR TITLE
add error handling for fontconfig using failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["font", "loading","loader", "wingdi", "fontconfig"]
 description = "A font loading utility written in and for rust."
 
 [dependencies]
+failure = "0.1.1"
 libc = "0.2.15"
 
 [target.'cfg(windows)'.dependencies]

--- a/examples/list-fonts.rs
+++ b/examples/list-fonts.rs
@@ -22,13 +22,13 @@ use fonts::system_fonts;
 
 fn main() {
 	// Enumerate all fonts
-    let sysfonts = system_fonts::query_all();
+    let sysfonts = system_fonts::query_all().unwrap();
     for string in &sysfonts {
         println!("{}", string);
     }
 
 	let mut property = system_fonts::FontPropertyBuilder::new().monospace().build();
-	let sysfonts = system_fonts::query_specific(&mut property);
+	let sysfonts = system_fonts::query_specific(&mut property).unwrap();
 	for string in &sysfonts {
 		println!("Monospaced font: {}", string);
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,13 +49,13 @@
 //!
 //! fn main() {
 //! 	// Enumerate all fonts
-//!     let sysfonts = system_fonts::query_all();
+//!     let sysfonts = system_fonts::query_all().unwrap();
 //!     for string in &sysfonts {
 //!         println!("{}", string);
 //!     }
 //!
 //! 	let mut property = system_fonts::FontPropertyBuilder::new().monospace().build();
-//! 	let sysfonts = system_fonts::query_specific(&mut property);
+//! 	let sysfonts = system_fonts::query_specific(&mut property).unwrap();
 //! 	for string in &sysfonts {
 //! 		println!("Monospaced font: {}", string);
 //! 	}
@@ -67,6 +67,8 @@
 //! ```
 
 
+#[macro_use]
+extern crate failure;
 extern crate libc;
 
 #[cfg(target_os = "windows")]

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -106,7 +106,7 @@ pub mod system_fonts {
     }
 
     /// Query the names of all fonts installed in the system
-    pub fn query_all() -> Vec<String> {
+    pub fn query_all() -> Result<Vec<String>, Error> {
         let family_names = core_text::font_collection::get_family_names();
         family_names.iter().map(|strref| {
             let family_name_ref: CFStringRef = unsafe { mem::transmute(strref) };
@@ -115,7 +115,7 @@ pub mod system_fonts {
     }
 
     /// Query the names of specifc fonts installed in the system
-    pub fn query_specific(property: &mut FontProperty) -> Vec<String> {
+    pub fn query_specific(property: &mut FontProperty) -> Result<Vec<String>, Error> {
         let descs: CFArray =
         unsafe {
             let descs = CTFontDescriptorCreateMatchingFontDescriptors(property.as_concrete_TypeRef(),

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -139,15 +139,14 @@ pub mod system_fonts {
 
     /// Query the names of all fonts installed in the system
     /// Note that only truetype fonts are supported
-    pub fn query_all() -> Vec<String> {
+    pub fn query_all() -> Result<Vec<String>, Error> {
         let mut config = FontPropertyBuilder::new().build();
-        query_specific(&mut config)
+        Ok(query_specific(&mut config))
     }
 
     /// Query the names of specifc fonts installed in the system
     /// Note that only truetype fonts are supported
-    pub fn query_specific(property: &mut FontProperty) -> Vec<String> {
-
+    pub fn query_specific(property: &mut FontProperty) -> Result<Vec<String>, Error> {
         let mut fonts = Vec::new();
         let mut f: FONTENUMPROCW = Some(callback_ttf);
         unsafe {
@@ -162,7 +161,7 @@ pub mod system_fonts {
             gdi32::EnumFontFamiliesExW(hdc, property, f, vec_pointer as LPARAM, 0);
             gdi32::DeleteDC(hdc);
         }
-        fonts
+        Ok(fonts)
     }
 
     #[allow(non_snake_case)]


### PR DESCRIPTION
Addresses #16 

It seems that fontconfig.rs is the only platform that unwraps Results at the moment, so the other platforms just have Result wrappers but never actually produce an Err value.