### PR TITLE
Update to winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,7 @@ description = "A font loading utility written in and for rust."
 libc = "0.2.15"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.2"
-user32-sys = "0.2"
-gdi32-sys = "0.2.0"
+winapi = { version = "0.3", default-features = false, features = ["winuser", "wingdi"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-text = "10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,6 @@ extern crate libc;
 
 #[cfg(target_os = "windows")]
 extern crate winapi;
-#[cfg(target_os = "windows")]
-extern crate gdi32;
-#[cfg(target_os = "windows")]
-extern crate user32;
 
 #[cfg(target_os = "windows")]
 mod win32;


### PR DESCRIPTION
Updates the winapi dependency from 0.2.* to 0.3.* - the reason I had to do this was because winapi 0.2.* has some linking problems when winapi is used as a submodule, that winapi 0.3 doesn't seem to have.